### PR TITLE
Ensure advanced image is rendered for export

### DIFF
--- a/Icons Designer/ContentView.swift
+++ b/Icons Designer/ContentView.swift
@@ -717,9 +717,12 @@ struct ContentView: View {
         panel.nameFieldStringValue = "FolderIcon.png"
         
         if panel.runModal() == .OK, let url = panel.url {
-            // 1) Render a 470×395 icon at 100% scale
+            // 1) Render a 470×395 icon at 100% scale. If advanced rendering is
+            // enabled we synchronously pre-process the image so the snapshot is
+            // fully rendered.
             let fullSizeIcon = FolderIconView(
-                resolutionScale: 1.0
+                resolutionScale: 1.0,
+                preRenderedImage: foldersViewModel.preRenderedImage()
             ).environmentObject(foldersViewModel)
             
             // 2) Use .snapshotAsNSImage (your existing logic)
@@ -791,7 +794,8 @@ struct ContentView: View {
     private func setFolderIcon(folderURL: URL) throws {
         // 1) Generate the same 470×395 icon as "Save as Image".
         let fullSizeIcon = FolderIconView(
-            resolutionScale: 1.0
+            resolutionScale: 1.0,
+            preRenderedImage: foldersViewModel.preRenderedImage()
         ).environmentObject(foldersViewModel)
         let nsImage = fullSizeIcon.snapshotAsNSImage()
         

--- a/Icons Designer/FoldersViewModel.swift
+++ b/Icons Designer/FoldersViewModel.swift
@@ -58,4 +58,85 @@ class FoldersViewModel: ObservableObject {
     @AppStorage("hideScale") var hideScale = false
     @AppStorage("hideOffset") var hideOffset = false
     @AppStorage("hideWeight") var hideWeight = false
+
+    /// Creates a synchronously processed image matching the advanced rendering
+    /// mode. This is used when exporting icons so that the snapshot reflects
+    /// the final tinted image without waiting for asynchronous tasks.
+    func preRenderedImage() -> NSImage? {
+        guard useAdvancedIconRendering,
+              imageType == .png,
+              let image = selectedImage else { return nil }
+
+        return Self.grayscaleMappedImage(from: image, tint: NSColor(symbolColor))
+    }
+
+    private static func grayscaleMappedImage(from original: NSImage, tint baseColor: NSColor) -> NSImage? {
+        guard let tiff = original.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let cgImage = bitmap.cgImage else { return nil }
+
+        let width = cgImage.width
+        let height = cgImage.height
+
+        guard let context = CGContext(data: nil,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: width * 4,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        guard let buffer = context.data else { return nil }
+        let ptr = buffer.bindMemory(to: UInt8.self, capacity: width * height * 4)
+
+        let baseR = baseColor.redComponent
+        let baseG = baseColor.greenComponent
+        let baseB = baseColor.blueComponent
+
+        let minC: CGFloat = 0.10
+        let maxC: CGFloat = 0.90
+        let whiteCutoff = 0.90
+
+        for i in 0..<(width * height) {
+            let o = i * 4
+            let originalAlpha = ptr[o + 3]
+            if originalAlpha == 0 { continue }
+
+            let r = Double(ptr[o])
+            let g = Double(ptr[o + 1])
+            let b = Double(ptr[o + 2])
+            let gray = (0.299*r + 0.587*g + 0.114*b) / 255.0
+
+            if gray > whiteCutoff {
+                ptr[o + 3] = 0
+                continue
+            }
+
+            let delta = max(min((gray - 0.5) / 0.25, 1.0), -1.0)
+            let scale: CGFloat = 0.25
+
+            var outR = baseR + delta * scale * (1 - baseR)
+            var outG = baseG + delta * scale * (1 - baseG)
+            var outB = baseB + delta * scale * (1 - baseB)
+
+            outR = clamp(outR, minC, maxC)
+            outG = clamp(outG, minC, maxC)
+            outB = clamp(outB, minC, maxC)
+
+            ptr[o]     = UInt8(outR * 255)
+            ptr[o + 1] = UInt8(outG * 255)
+            ptr[o + 2] = UInt8(outB * 255)
+            ptr[o + 3] = originalAlpha
+        }
+
+        guard let outputCG = context.makeImage() else { return nil }
+        return NSImage(cgImage: outputCG, size: NSSize(width: width, height: height))
+    }
+
+    private static func clamp<T: Comparable>(_ val: T, _ min: T, _ max: T) -> T {
+        Swift.max(min, Swift.min(max, val))
+    }
 }

--- a/Icons Designer/The Folder/FolderPresetPreview.swift
+++ b/Icons Designer/The Folder/FolderPresetPreview.swift
@@ -31,11 +31,11 @@ struct FolderPresetPreview: View {
     var body: some View {
         ZStack {
             PresetFolderIconView(
+                resolutionScale: 0.25,
                 topShapeColor: .constant(Color(hex: color1)),
                 bottomShapeColor: .constant(Color(hex: color2)),
                 symbolColor: .constant(Color(hex: color1)),
-                symbolOpacity: .constant(0.5),
-                resolutionScale: 0.25
+                symbolOpacity: .constant(0.5)
             )
             .scaleEffect(0.15)
             .frame(width: 70, height: 60)


### PR DESCRIPTION
## Summary
- allow passing a pre-rendered image to `FolderIconView` and `PresetFolderIconView`
- synchronously generate tinted images in `FoldersViewModel`
- use the pre-rendered image when saving PNGs or setting folder icons

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68427aad44e0832d842a519655418c59